### PR TITLE
help diagnose faults by writing out json data when exception thrown

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,17 @@ The object passed to the callback will be merged with the input data and passed 
 For an example check `samples/post-processing.js`
 
 ### Debug
+If your post processing script or template throws an exception, the JSON data will be written to the file system in the same folder as the processing script.
 
-If the output is not what you expect, set the DEBUG environment variable:
+The DEBUG environment variable can also be useful for fault diagnosis:
 
 #### Linux
-    DEBUG=release-notes:* git-release-notes ...
+    DEBUG=release-notes:*
+    git-release-notes ...
 
 #### Windows
 
-    SET DEBUG=release-notes:*
+    SET DEBUG=release-notes:cli,release-notes:externalscript
     git-release-notes ...
+
+Note the filtering options available: `release-notes:cli` and `release-notes:externalscript`


### PR DESCRIPTION
This is a minor fix to 1.1 to make it easier to debug faults in the external script 
* by writing the JSON out to file on exception
* injecting the debug object

Looking at the diff - I think my tabs to spaces is wrong?
Let me know the correct settings if so