### PR TITLE
Help diagnose faults by writing out json data when exception thrown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+[*]
+charset=utf-8
+end_of_line=lf
+trim_trailing_whitespace=true
+insert_final_newline=true
+indent_style=tab
+indent_size=2
+spaces_around_brackets=both
+
+[{.eslintrc,.babelrc,.stylelintrc,.firebaserc,*.bowerrc,*.jsb3,*.jsb2,*.json,*.config,*.yml,*.yaml}]
+indent_style=space
+indent_size=2

--- a/README.md
+++ b/README.md
@@ -127,13 +127,17 @@ The object passed to the callback will be merged with the input data and passed 
 For an example check `samples/post-processing.js`
 
 ### Debug
+If your post processing script or template throws an exception, the JSON data will be written to the file system in the same folder as the processing script.
 
-If the output is not what you expect, set the DEBUG environment variable:
+The DEBUG environment variable can also be useful for fault diagnosis:
 
 #### Linux
-    DEBUG=release-notes:* git-release-notes ...
+    DEBUG=release-notes:*
+    git-release-notes ...
 
 #### Windows
 
-    SET DEBUG=release-notes:*
+    SET DEBUG=release-notes:cli,release-notes:externalscript
     git-release-notes ...
+
+Note the filtering options available: `release-notes:cli` and `release-notes:externalscript`

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ module.exports = function(data, callback) {
    *   commits: [], // the array of commits as described above
    *   range: '<since>..<until>',
    *   dateFnsFormat: function () {},
+   *   debug: function() {}, // utility function to log debug messages
    * }
    *
    * Do all the processing you need and when ready call the callback passing the new data structure
@@ -140,4 +141,4 @@ The DEBUG environment variable can also be useful for fault diagnosis:
     SET DEBUG=release-notes:cli,release-notes:externalscript
     git-release-notes ...
 
-Note the filtering options available: `release-notes:cli` and `release-notes:externalscript`
+Note the filtering options available: `release-notes:cli`, `release-notes:externalscript`, `release-notes:data`

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "posttest": "npm run lint",
     "test-html": "node index.js -- 32a369f..0419636 ./templates/html.ejs > ./samples/output-html.html",
     "test-html-bootstrap": "cross-env DEBUG=* node index.js -- 32a369f..0419636 ./templates/html-bootstrap.ejs > ./samples/output-html-bootstrap.html",
-    "test-markdown": "node index.js -- 32a369f..0419636 ./templates/markdown.ejs > ./samples/output-markdown.md"
+    "test-markdown": "node index.js -- 32a369f..0419636 ./templates/markdown.ejs > ./samples/output-markdown.md",
+    "test-script": "node index.js -s ./samples/post-processing.js 32a369f..0419636 ./templates/markdown.ejs"
   },
   "version": "1.1.0",
   "dependencies": {


### PR DESCRIPTION
@neutmute I've modified your commit slightly

I don't like writing to a file, I hate when scripts generate stuff in random places, so it now outputs into `debug`.

I've also added `.editorconfig` so your editor should respect the original indentation