### PR TITLE
Add option for using "--merges" with git log.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ More advanced options are
 * `m` or `meaning` Meaning of capturing block in title's regular expression
 * `f` or `file` JSON Configuration file, better option when you don't want to pass all parameters to the command line, for an example see [options.json](https://github.com/ariatemplates/git-release-notes/blob/master/options.json)
 * `s` or `script` External script for post-processing commits
+* `c` or `use-merge-commits` When the Git log command is executed it is with the `--merges` flag instead of `--no-merges`
 
 #### Title Parsing
 

--- a/index.js
+++ b/index.js
@@ -22,13 +22,17 @@ var argv = require("optimist").usage("git-release-notes [<options>] <since>..<un
 .options("s", {
 	"alias": "script"
 })
+.options("c", {
+	"alias": "use-merge-commits"
+})
 .describe({
 	"f": "Configuration file",
 	"p": "Git project path",
 	"t": "Commit title regular expression",
 	"m": "Meaning of capturing block in title's regular expression",
 	"b": "Git branch, defaults to master",
-	"s": "External script to rewrite the commit history"
+	"s": "External script to rewrite the commit history",
+	"c": "Only use merge commits"
 })
 .boolean("version")
 .check(function (argv) {
@@ -83,7 +87,8 @@ fs.readFile(template, function (err, templateContent) {
 				range: argv._[0],
 				title: new RegExp(options.t),
 				meaning: Array.isArray(options.m) ? options.m: [options.m],
-				cwd: options.p
+				cwd: options.p,
+				useMergeCommits: options.c
 			}, function (commits) {
 				postProcess(templateContent, commits);
 			});
@@ -105,7 +110,8 @@ function getOptions (callback) {
 						b: stored.b || stored.branch || argv.b,
 						t: stored.t || stored.title || argv.t,
 						m: stored.m || stored.meaning || argv.m,
-						p: stored.p || stored.path || argv.p
+						p: stored.p || stored.path || argv.p,
+						c: stored.c || stored.mergeCommits || argv.c
 					};
 				} catch (ex) {
 					console.error("Invalid JSON in configuration file");

--- a/lib/git.js
+++ b/lib/git.js
@@ -3,7 +3,8 @@ var parser = require("debug")("release-notes:parser");
 
 exports.log = function (options, callback) {
 	var spawn = require("child_process").spawn;
-	var gitArgs = ["log", "--no-color", "--no-merges", "--branches=" + options.branch, "--format=" + formatOptions, options.range];
+	var commits = options.useMergeCommits ? "--merges" : "--no-merges"
+	var gitArgs = ["log", "--no-color", commits, "--branches=" + options.branch, "--format=" + formatOptions, options.range];
 	debug("Spawning git with args %o", gitArgs);
 	var gitLog = spawn("git", gitArgs, {
 		cwd : options.cwd,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-markdown": "node index.js -- 32a369f..0419636 ./templates/markdown.ejs > ./samples/output-markdown.md",
     "test-script": "node index.js -s ./samples/post-processing.js 32a369f..0419636 ./templates/markdown.ejs"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "dependencies": {
     "date-fns": "^1.28.4",
     "debug": "^2.6.0",


### PR DESCRIPTION
I want to use `--merges` and not `--no-merges`.

This enables me to create a change-log that uses merged PRs:

```markdown
## v0.11.1 (2017-8-17)
* [#113](https://github.com/org/repo/pull/113) - Fix bug JIRA-1234.
* [#116](https://github.com/org/repo/pull/116) - New feature that does XYZ.
* [#114](https://github.com/org/repo/pull/114) - Remove unused/dead code.
* [#112](https://github.com/org/repo/pull/112) - Write docs and update README.

## v0.11.0 (2017-8-10)
* [#110](https://github.com/org/repo/pull/110) - New feature that does ABC.
```

Let me know if there's a better way of doing this. I just added a new option `-c` to specify to use only merge commits.