### PR TITLE
Propagate error code from git

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -28,6 +28,9 @@ exports.log = function (options, callback) {
 			} else {
 				callback([]);
 			}
+		} else {
+			// propagate error code
+			process.exit(code);
 		}
 	});
 };


### PR DESCRIPTION
This propagates the exit status from git log to git-release-notes so that scripts using it can tell if something went wrong. To reproduce the bug:

    mkdir temp
    cd temp
    git init
    touch template
    git-release-notes missing..master ./template

There is a message:

    fatal: ambiguous argument 'missing..master': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'

If you run `echo $?` after it shows a `0` exit code.

Thanks!