### PR TITLE
[NEW] Filter commits with a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ More advanced options are
 * `m` or `meaning` Meaning of capturing block in title's regular expression
 * `f` or `file` JSON Configuration file, better option when you don't want to pass all parameters to the command line, for an example see [options.json](https://github.com/ariatemplates/git-release-notes/blob/master/options.json)
 * `s` or `script` External script for post-processing commits
+* `g` or `grep` List only commits having title matching the regular expression
 * `c` or `merge-commits` List only merge commits, `git log` command is executed with the `--merges` flag instead of `--no-merges`
 
 #### Title Parsing

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ var argv = require("optimist").usage("git-release-notes [<options>] <since>..<un
 .options("s", {
 	"alias": "script"
 })
+.options("g", {
+	"alias": "grep",
+	"default": "(.*)"
+})
 .boolean("c")
 .alias("c", "merge-commits")
 .describe({
@@ -31,7 +35,8 @@ var argv = require("optimist").usage("git-release-notes [<options>] <since>..<un
 	"m": "Meaning of capturing block in title's regular expression",
 	"b": "Git branch, defaults to master",
 	"s": "External script to rewrite the commit history",
-	"c": "Only use merge commits"
+	"c": "Only use merge commits",
+	"g": "Grep commits based on regular expression applied to against text in title"
 })
 .boolean("version")
 .check(function (argv) {
@@ -87,7 +92,8 @@ fs.readFile(template, function (err, templateContent) {
 				title: new RegExp(options.t),
 				meaning: Array.isArray(options.m) ? options.m: [options.m],
 				cwd: options.p,
-				mergeCommits: options.c
+				mergeCommits: options.c,
+				regex: options.g
 			}, function (commits) {
 				postProcess(templateContent, commits);
 			});

--- a/lib/git.js
+++ b/lib/git.js
@@ -24,6 +24,7 @@ exports.log = function (options, callback) {
 			if (allCommits) {
 				// Build the list of commits from git log
 				var commits = processCommits(allCommits, options);
+				commits = filterCommits(commits, options);
 				callback(commits);
 			} else {
 				callback([]);
@@ -121,4 +122,25 @@ function parseTitle (title, options) {
 
 function normalizeNewlines(message) {
 	return message.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/^\uFEFF/, '');
+}
+
+function filterCommits(commits, options) {
+	var expression = new RegExp(options.regex);
+	parser("options.regex");
+	parser(options.regex);
+	if(!expression) {
+		return commits;
+	}
+	var filteredCommits = [];
+	for (var i = 0, len = commits.length; i < len; i++) {
+		var commit = commits[i];
+		parser("title");
+		parser(commit.title);
+		var match = commit.title.match(expression);
+		if(match){
+			parser("including commit");
+			filteredCommits.push(commit);
+		}
+	}
+	return filteredCommits;
 }


### PR DESCRIPTION
Objective here is to be able to **filter** commits.

This new option permits _for instance_ to create a release note for a specific client (without showing to client A what has client B).
It could have other uses but this is the one described above that is interesting me for now.

Thanks !