### PR TITLE
Add -o option to tunnel options to git log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ More advanced options are
 * `f` or `file` JSON Configuration file, better option when you don't want to pass all parameters to the command line, for an example see [options.json](https://github.com/ariatemplates/git-release-notes/blob/master/options.json)
 * `s` or `script` External script for post-processing commits
 * `c` or `merge-commits` List only merge commits, `git log` command is executed with the `--merges` flag instead of `--no-merges`
+* `o` or `gitlog-option` to add some additional git log options **and** ignores the `merge-commits` option, this is direct given to `git log` by adding a `--` to each longname option from the array (e.g. `-o first-parent`). 
 
 #### Title Parsing
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ var argv = require("optimist").usage("git-release-notes [<options>] <since>..<un
 .options("s", {
 	"alias": "script"
 })
+.options("o", {
+	"alias": "gitlog-option",
+	"default" : []
+})
 .boolean("c")
 .alias("c", "merge-commits")
 .describe({
@@ -31,7 +35,8 @@ var argv = require("optimist").usage("git-release-notes [<options>] <since>..<un
 	"m": "Meaning of capturing block in title's regular expression",
 	"b": "Git branch, defaults to master",
 	"s": "External script to rewrite the commit history",
-	"c": "Only use merge commits"
+	"c": "Only use merge commits",
+	"o": "Additional git log options AND ignore 'c' option"
 })
 .boolean("version")
 .check(function (argv) {
@@ -87,7 +92,8 @@ fs.readFile(template, function (err, templateContent) {
 				title: new RegExp(options.t),
 				meaning: Array.isArray(options.m) ? options.m: [options.m],
 				cwd: options.p,
-				mergeCommits: options.c
+				mergeCommits: options.c,
+				additionalOptions: Array.isArray(options.o) ? options.o : [options.o]
 			}, function (commits) {
 				postProcess(templateContent, commits);
 			});

--- a/lib/git.js
+++ b/lib/git.js
@@ -3,8 +3,18 @@ var parser = require("debug")("release-notes:parser");
 
 exports.log = function (options, callback) {
 	var spawn = require("child_process").spawn;
-	var commits = options.mergeCommits ? "--merges" : "--no-merges";
-	var gitArgs = ["log", "--no-color", commits, "--branches=" + options.branch, "--format=" + formatOptions, options.range];
+	var addOpts = options.mergeCommits ? "--merges" : "--no-merges";
+	var gitArgs = ["log", "--no-color"]
+	if (options.additionalOptions.length > 0) {
+		options.additionalOptions.forEach(function(o) {
+			gitArgs.push("--" + o);
+		})
+	}
+	else {
+		gitArgs.push (addOpts)
+	}
+	gitArgs.push ("--format=" + formatOptions);
+	gitArgs.push (options.range);
 	debug("Spawning git with args %o", gitArgs);
 	var gitLog = spawn("git", gitArgs, {
 		cwd : options.cwd,

--- a/lib/git.js
+++ b/lib/git.js
@@ -13,6 +13,7 @@ exports.log = function (options, callback) {
 	else {
 		gitArgs.push (addOpts)
 	}
+	gitArgs.push ("--branches=" + options.branch);
 	gitArgs.push ("--format=" + formatOptions);
 	gitArgs.push (options.range);
 	debug("Spawning git with args %o", gitArgs);


### PR DESCRIPTION
There are some more options which offer git log to define the set of output commits, with this option an arbitrary long option can be given to the underlying git call.
Hopefully, this will be future safe for other requests to change the result set.


