### PR TITLE
Added option to ignore case of title's regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ More advanced options are
 * `p` or `path` Git project path, defaults to the current working path
 * `b` or `branch` Git branch, defaults to `master`
 * `t` or `title` Regular expression to parse the commit title (see next chapter)
+* `i` or `ignore-case` Ignore case flag for title's regular expression. `/.*/` becomes `/.*/i`
 * `m` or `meaning` Meaning of capturing block in title's regular expression
 * `f` or `file` JSON Configuration file, better option when you don't want to pass all parameters to the command line, for an example see [options.json](https://github.com/ariatemplates/git-release-notes/blob/master/options.json)
 * `s` or `script` External script for post-processing commits

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ var argv = require("optimist").usage("git-release-notes [<options>] <since>..<un
 	"alias": "title",
 	"default": "(.*)"
 })
+.boolean("i")
+.alias("i", "ignore-case")
 .options("m", {
 	"alias": "meaning",
 	"default": ['type']
@@ -28,6 +30,7 @@ var argv = require("optimist").usage("git-release-notes [<options>] <since>..<un
 	"f": "Configuration file",
 	"p": "Git project path",
 	"t": "Commit title regular expression",
+	"i": "Ignore case of title's regular expression",
 	"m": "Meaning of capturing block in title's regular expression",
 	"b": "Git branch, defaults to master",
 	"s": "External script to rewrite the commit history",
@@ -84,7 +87,7 @@ fs.readFile(template, function (err, templateContent) {
 			git.log({
 				branch: options.b,
 				range: argv._[0],
-				title: new RegExp(options.t),
+				title: options.i ? new RegExp(options.t, 'i') : new RegExp(options.t),
 				meaning: Array.isArray(options.m) ? options.m: [options.m],
 				cwd: options.p,
 				mergeCommits: options.c
@@ -108,6 +111,7 @@ function getOptions (callback) {
 					options = {
 						b: stored.b || stored.branch || argv.b,
 						t: stored.t || stored.title || argv.t,
+						i: stored.i || stored.ignoreCase || argv.i,
 						m: stored.m || stored.meaning || argv.m,
 						p: stored.p || stored.path || argv.p,
 						c: stored.c || stored.mergeCommits || argv.c


### PR DESCRIPTION
I've got a specific case where I'm parsing JIRA issue IDs from commit messages, which are sometimes incorrectly committed in lowercase. This flag alleviates that.

Let me know if you have any feedback!