### PR TITLE
Add tag information on commit array

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Several template variables are made available to the script running inside the t
 * `committerEmail` committer email (%ce)
 * `committerDate` committer date (%cD)
 * `title` subject (%s)
+* `tag` tag (%D)
 * `messageLines` array of body lines (%b)
 
 `dateFnsFormat` is the date-fns [format](https://date-fns.org/docs/format) function. See the [html-bootstrap](https://github.com/ariatemplates/git-release-notes/blob/master/templates/html-bootstrap.ejs) for sample usage.

--- a/lib/__tests__/git.test.js
+++ b/lib/__tests__/git.test.js
@@ -45,8 +45,20 @@ describe('log commits', () => {
       'Add option for using "--merges" with git log',
     ]);
   });
+
+  it('list tags', () => {
+    const OPTIONS = {
+      branch: 'testing-branch',
+      range: '575fef3..28b863e',
+    };
+
+    return expectTags(OPTIONS).toEqual([
+      'v2.1.0',
+      'no tag',
+      'v2.0.0'
+    ]);
+  });
 });
 
-function expectCommits(options) {
-  return expect(gitLog(options).then((commits) => commits.map((c) => c.title))).resolves;
-}
+const expectCommits = (_) => expect(gitLog(_).then((commits) => commits.map((c) => c.title))).resolves;
+const expectTags = (_) => expect(gitLog(_).then((commits) => commits.map((c) => c.tag || 'no tag'))).resolves;

--- a/lib/git.js
+++ b/lib/git.js
@@ -52,7 +52,7 @@ var newCommit = "___";
 var formatOptions = [
 	newCommit, "sha1:%H", "authorName:%an", "authorEmail:%ae", "authorDate:%aD",
 	"committerName:%cn", "committerEmail:%ce", "committerDate:%cD",
-	"title:%s", "%w(80,1,1)%b"
+	"title:%s", "%D", "%w(80,1,1)%b"
 ].join("%n");
 
 function processCommits (commitMessages, options) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -5,7 +5,7 @@ exports.log = function (options) {
 	return new Promise(function (resolve, reject) {
 		var spawn = require("child_process").spawn;
 		var gitArgs = ["log", "--no-color"];
-		if (options.additionalOptions.length > 0) {
+		if (options.additionalOptions && options.additionalOptions.length > 0) {
 			options.additionalOptions.forEach(function(o) {
 				gitArgs.push("--" + o);
 			});
@@ -15,6 +15,7 @@ exports.log = function (options) {
 		gitArgs.push(
 			"--branches=" + options.branch,
 			"--format=" + formatOptions,
+			"--decorate=full",
 			options.range
 		);
 		debug("Spawning git with args %o", gitArgs);
@@ -82,6 +83,11 @@ function processCommits (commitMessages, options) {
 				// The parser doesn't return a title
 				workingCommit.title = line.message;
 			}
+		} else if (line.type === "tag") {
+			parser("Trying to parse tag %o", line.message);
+			var tag = parseTag(line.message);
+			parser("Parse tag %o", tag);
+			workingCommit[line.type] = tag;
 		} else {
 			workingCommit[line.type] = line.message;
 		}
@@ -113,7 +119,7 @@ function parseLine (line) {
 
 function parseTitle (title, options) {
 	var expression = options.title;
-	var names = options.meaning;
+	var names = options.meaning || [];
 	parser("Parsing title '%s' with regular expression '%s' and meanings %o", title, expression, names);
 
 	var match = title.match(expression);
@@ -130,6 +136,15 @@ function parseTitle (title, options) {
 		}
 		return builtObject;
 	}
+}
+
+function parseTag (line) {
+	var refs = line.split(/(refs)\/(tags|remotes|heads)\//);
+	var tagIndex = refs.findIndex((token, index, all) => all[index - 2] === 'refs' && all[index - 1] === 'tags');
+	if (tagIndex === refs.length - 1) {
+		return refs[tagIndex];
+	}
+	return refs[tagIndex].replace(/, $/, '');
 }
 
 function normalizeNewlines(message) {


### PR DESCRIPTION
Took the commit from #49 added some tests and improved on the parsing logic to remove additional information that is not useful.

When you have a tag and a remote branch on the same commit, git log will say `tag:v1.0.0, origin/branch-1`.
The function `parseTag` now guarantees that only the tag is set into `tag` instead of the full string

Closes #49